### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ibm.yml
+++ b/.github/workflows/ibm.yml
@@ -8,6 +8,9 @@
 
 name: Build and Deploy to IKS
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/guruh46/security/code-scanning/2](https://github.com/guruh46/guruh46/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level (root level) to explicitly define the permissions for the `GITHUB_TOKEN`. Based on the workflow's operations, the minimal required permission is `contents: read`, as the workflow does not modify repository contents or perform other actions requiring write permissions. This change will ensure that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- greptile_comment -->

## Greptile Summary

Your free trial has ended. If you'd like to continue receiving code reviews, you can add a payment method here: [https://app.greptile.com/review/github](https://app.greptile.com/review/github).



<sub>💡 (1/5) You can manually trigger the bot by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->